### PR TITLE
Feat: API to update the vendor account

### DIFF
--- a/src/apps/backend/modules/vendor_account/errors.py
+++ b/src/apps/backend/modules/vendor_account/errors.py
@@ -7,6 +7,7 @@ class VendorAccountWithSameNameAndAccountExistsError(AppError):
         message = f"A vendor account with the name {vendor_account_name} has already been created. Please choose a different name."
         super().__init__(code=VendorAccountErrorCode.NAME_ALREADY_EXISTS, https_status_code=409, message=message)
 
+
 class VendorAccountNotFoundError(AppError):
     def __init__(self, vendor_account_id: str) -> None:
         message = f"Vendor account with id {vendor_account_id} not found. Please verify the id and try again."

--- a/src/apps/backend/modules/vendor_account/errors.py
+++ b/src/apps/backend/modules/vendor_account/errors.py
@@ -6,3 +6,8 @@ class VendorAccountWithSameNameAndAccountExistsError(AppError):
     def __init__(self, vendor_account_name: str) -> None:
         message = f"A vendor account with the name {vendor_account_name} has already been created. Please choose a different name."
         super().__init__(code=VendorAccountErrorCode.NAME_ALREADY_EXISTS, https_status_code=409, message=message)
+
+class VendorAccountNotFoundError(AppError):
+    def __init__(self, vendor_account_id: str) -> None:
+        message = f"Vendor account with id {vendor_account_id} not found. Please verify the id and try again."
+        super().__init__(code=VendorAccountErrorCode.VENDOR_ACCOUNT_NOT_FOUND, https_status_code=404, message=message)

--- a/src/apps/backend/modules/vendor_account/internal/vendor_account_reader.py
+++ b/src/apps/backend/modules/vendor_account/internal/vendor_account_reader.py
@@ -1,5 +1,6 @@
 from bson import ObjectId
 
+from modules.vendor_account.errors import VendorAccountNotFoundError
 from modules.vendor_account.internal.store.vendor_account_repository import VendorAccountRepository
 from modules.vendor_account.types import VendorAccount, VendorType
 from modules.vendor_account.internal.vendor_account_util import VendorAccountUtil
@@ -21,3 +22,14 @@ class VendorAccountReader:
 
         if vendor_account_db:
             return VendorAccountUtil.convert_vendor_account_db_to_vendor_account(vendor_account_db=vendor_account_db)
+
+    @staticmethod
+    def get_vendor_account_by_id(account_id: str, vendor_account_id: str) -> VendorAccount:
+        vendor_account_db = VendorAccountRepository.collection().find_one(
+            {"account_id": ObjectId(account_id), "active": True, "_id": ObjectId(vendor_account_id)}
+        )
+
+        if vendor_account_db is None:
+            raise VendorAccountNotFoundError(vendor_account_id=vendor_account_id)
+
+        return VendorAccountUtil.convert_vendor_account_db_to_vendor_account(vendor_account_db=vendor_account_db)

--- a/src/apps/backend/modules/vendor_account/internal/vendor_account_writer.py
+++ b/src/apps/backend/modules/vendor_account/internal/vendor_account_writer.py
@@ -1,10 +1,11 @@
 from bson import ObjectId
 from datetime import datetime, timezone
+from pymongo import ReturnDocument
 
 from modules.vendor_account.internal.store.vendor_account_repository import VendorAccountRepository
 from modules.vendor_account.internal.vendor_account_reader import VendorAccountReader
 from modules.vendor_account.internal.vendor_account_util import VendorAccountUtil
-from modules.vendor_account.types import CreateVendorAccountParams
+from modules.vendor_account.types import CreateVendorAccountParams, UpdateVendorAccountParams
 from modules.vendor_account.types import VendorAccount
 from modules.vendor_account.errors import VendorAccountWithSameNameAndAccountExistsError
 
@@ -31,3 +32,24 @@ class VendorAccountWriter:
         result = VendorAccountRepository.collection().insert_one(vendor_account_data)
         vendor_account_db = VendorAccountRepository.collection().find_one({"_id": result.inserted_id})
         return VendorAccountUtil.convert_vendor_account_db_to_vendor_account(vendor_account_db=vendor_account_db)
+
+    @staticmethod
+    def update_vendor_account(params: UpdateVendorAccountParams) -> VendorAccount:
+        vendor_account = VendorAccountReader.get_vendor_account_by_id(account_id=params.account_id, vendor_account_id=params.vendor_account_id)
+
+        duplicate_vendor_account = VendorAccountReader.get_vendor_account_optional(
+            account_id=vendor_account.account_id,
+            vendor_account_name=params.name,
+            vendor_type=vendor_account.vendor_type,
+        )
+
+        if duplicate_vendor_account and duplicate_vendor_account.id != params.vendor_account_id:
+            raise VendorAccountWithSameNameAndAccountExistsError(vendor_account_name=params.name)
+
+        updated_vendor_account = VendorAccountRepository.collection().find_one_and_update(
+            {"_id": ObjectId(params.vendor_account_id)},
+            {"$set": {"name": params.name}},
+            return_document=ReturnDocument.AFTER,
+        )
+
+        return VendorAccountUtil.convert_vendor_account_db_to_vendor_account(vendor_account_db=updated_vendor_account)

--- a/src/apps/backend/modules/vendor_account/rest_api/vendor_account_router.py
+++ b/src/apps/backend/modules/vendor_account/rest_api/vendor_account_router.py
@@ -6,5 +6,13 @@ from modules.vendor_account.rest_api.vendor_account_view import VendorAccountVie
 class VendorAccountRouter:
     @staticmethod
     def create_route(*, blueprint: Blueprint) -> Blueprint:
-        blueprint.add_url_rule("/accounts/<account_id>/vendor-accounts", view_func=VendorAccountView.as_view("vendor_account_view"))
+        blueprint.add_url_rule(
+            "/accounts/<account_id>/vendor-accounts", view_func=VendorAccountView.as_view("vendor_account_view")
+        )
+
+        blueprint.add_url_rule(
+            "/accounts/<account_id>/vendor-accounts/<vendor_account_id>",
+            view_func=VendorAccountView.as_view("vendor_account_update"),
+            methods=["PUT"],
+        )
         return blueprint

--- a/src/apps/backend/modules/vendor_account/rest_api/vendor_account_view.py
+++ b/src/apps/backend/modules/vendor_account/rest_api/vendor_account_view.py
@@ -5,7 +5,7 @@ from flask.typing import ResponseReturnValue
 from flask.views import MethodView
 
 from modules.vendor_account.vendor_account_service import VendorAccountService
-from modules.vendor_account.types import CreateVendorAccountParams
+from modules.vendor_account.types import CreateVendorAccountParams, UpdateVendorAccountParams
 from modules.access_token.rest_api.access_auth_middleware import access_auth_middleware
 
 
@@ -13,8 +13,17 @@ class VendorAccountView(MethodView):
     @access_auth_middleware
     def post(self, account_id: str) -> ResponseReturnValue:
         request_data = request.get_json()
-        request_data['account_id'] = account_id 
+        request_data["account_id"] = account_id
         vendor_account_params = CreateVendorAccountParams(**request_data)
         vendor_account = VendorAccountService.create_vendor_account(params=vendor_account_params)
         vendor_account_dict = asdict(vendor_account)
         return jsonify(vendor_account_dict), 201
+
+    @access_auth_middleware
+    def put(self, account_id: str, vendor_account_id: str) -> ResponseReturnValue:
+        request_data = request.get_json()
+        request_data["account_id"] = account_id
+        request_data["vendor_account_id"] = vendor_account_id
+        vendor_account = VendorAccountService.update_vendor_account(params=UpdateVendorAccountParams(**request_data))
+        vendor_account_dict = asdict(vendor_account)
+        return jsonify(vendor_account_dict), 200

--- a/src/apps/backend/modules/vendor_account/types.py
+++ b/src/apps/backend/modules/vendor_account/types.py
@@ -18,7 +18,13 @@ class CreateVendorAccountParams:
     name: str
     vendor_type: VendorType
 
+@dataclass(frozen=True)
+class UpdateVendorAccountParams:
+    account_id: str
+    name: str
+    vendor_account_id: str
 
 @dataclass(frozen=True)
 class VendorAccountErrorCode:
     NAME_ALREADY_EXISTS: str = "VENDOR_ACCOUNT_ERR_01"
+    VENDOR_ACCOUNT_NOT_FOUND: str = "VENDOR_ACCOUNT_ERR_02"

--- a/src/apps/backend/modules/vendor_account/vendor_account_service.py
+++ b/src/apps/backend/modules/vendor_account/vendor_account_service.py
@@ -1,4 +1,4 @@
-from modules.vendor_account.types import CreateVendorAccountParams, VendorAccount
+from modules.vendor_account.types import CreateVendorAccountParams, UpdateVendorAccountParams, VendorAccount
 from modules.vendor_account.internal.vendor_account_writer import VendorAccountWriter
 
 
@@ -6,3 +6,7 @@ class VendorAccountService:
     @staticmethod
     def create_vendor_account(params: CreateVendorAccountParams) -> VendorAccount:
         return VendorAccountWriter.create_vendor_account(params=params)
+
+    @staticmethod
+    def update_vendor_account(params: UpdateVendorAccountParams) -> VendorAccount:
+        return VendorAccountWriter.update_vendor_account(params=params)

--- a/src/apps/backend/tests/modules/vendor_account/test_vendor_account_api.py
+++ b/src/apps/backend/tests/modules/vendor_account/test_vendor_account_api.py
@@ -25,7 +25,6 @@ class TestVendorAccountApi(BaseTestVendorAccount):
         self.account_id = account.id
         self.access_token = access_token.token
 
-
     def test_create_vendor_account(self) -> None:
         payload = json.dumps({"name": "Amz-01", "vendor_type": "AMAZON"})
 
@@ -57,7 +56,10 @@ class TestVendorAccountApi(BaseTestVendorAccount):
         assert response.status_code == 409
         assert response.json
         assert response.json.get("code") == VendorAccountErrorCode.NAME_ALREADY_EXISTS
-        assert response.json.get("message") == f"A vendor account with the name {params.name} has already been created. Please choose a different name."
+        assert (
+            response.json.get("message")
+            == f"A vendor account with the name {params.name} has already been created. Please choose a different name."
+        )
 
     def test_create_vendor_account_with_same_account_and_name_but_for_different_vendor(self) -> None:
         # Pre test setup
@@ -77,3 +79,63 @@ class TestVendorAccountApi(BaseTestVendorAccount):
             assert response.json.get("account_id") == self.account_id
             assert response.json.get("name") == params.name
             assert response.json.get("vendor_type") == "Croma"
+
+    def test_update_vendor_account(self) -> None:
+        # Pre test setup
+        params = CreateVendorAccountParams(account_id=self.account_id, name="Amz-01", vendor_type="AMAZON")
+
+        vendor_account = VendorAccountService.create_vendor_account(params)
+        # Pre test setup end
+
+        with app.test_client() as client:
+            response = client.put(
+                f"http://127.0.0.1:8080/api/accounts/{self.account_id}/vendor-accounts/{vendor_account.id}",
+                headers={"Content-Type": "application/json", "Authorization": f"Bearer {self.access_token}"},
+                data=json.dumps({"name": "Amz-01"}),
+            )
+            assert response.status_code == 200
+            assert response.json, f"No response from API with status code:: {response.status}"
+            assert response.json.get("account_id") == self.account_id
+            assert response.json.get("id") == vendor_account.id
+            assert response.json.get("name") == "Amz-01"
+            assert response.json.get("vendor_type") == "AMAZON"
+
+    def test_update_vendor_account_with_an_invalid_vendor_account_id(self) -> None:
+        with app.test_client() as client:
+            response = client.put(
+                f"http://127.0.0.1:8080/api/accounts/{self.account_id}/vendor-accounts/66b2400af6d99e62d6e7992c",
+                headers={"Content-Type": "application/json", "Authorization": f"Bearer {self.access_token}"},
+                data=json.dumps({"name": "Amz-01"}),
+            )
+        assert response.status_code == 404
+        assert response.json
+        assert response.json.get("code") == VendorAccountErrorCode.VENDOR_ACCOUNT_NOT_FOUND
+        assert (
+            response.json.get("message")
+            == "Vendor account with id 66b2400af6d99e62d6e7992c not found. Please verify the id and try again."
+        )
+
+    def test_update_vendor_account_with_duplicate_name(self) -> None:
+        # Pre test setup
+        params_one = CreateVendorAccountParams(account_id=self.account_id, name="Amz-01", vendor_type="AMAZON")
+
+        VendorAccountService.create_vendor_account(params_one)
+
+        params_two = CreateVendorAccountParams(account_id=self.account_id, name="Amz-02", vendor_type="AMAZON")
+
+        vendor_account = VendorAccountService.create_vendor_account(params_two)
+        # Pre test setup end
+
+        with app.test_client() as client:
+            response = client.put(
+                f"http://127.0.0.1:8080/api/accounts/{self.account_id}/vendor-accounts/{vendor_account.id}",
+                headers={"Content-Type": "application/json", "Authorization": f"Bearer {self.access_token}"},
+                data=json.dumps({"name": "Amz-01"}),
+            )
+        assert response.status_code == 409
+        assert response.json
+        assert response.json.get("code") == VendorAccountErrorCode.NAME_ALREADY_EXISTS
+        assert (
+            response.json.get("message")
+            == f"A vendor account with the name {params_one.name} has already been created. Please choose a different name."
+        )

--- a/src/apps/backend/tests/modules/vendor_account/test_vendor_account_service.py
+++ b/src/apps/backend/tests/modules/vendor_account/test_vendor_account_service.py
@@ -1,8 +1,8 @@
 from modules.account.account_service import AccountService
 from modules.account.types import CreateAccountParams
 from modules.vendor_account.vendor_account_service import VendorAccountService
-from modules.vendor_account.errors import VendorAccountWithSameNameAndAccountExistsError
-from modules.vendor_account.types import VendorAccountErrorCode, CreateVendorAccountParams
+from modules.vendor_account.errors import VendorAccountNotFoundError, VendorAccountWithSameNameAndAccountExistsError
+from modules.vendor_account.types import UpdateVendorAccountParams, VendorAccountErrorCode, CreateVendorAccountParams
 from tests.modules.vendor_account.base_test_vendor_account import BaseTestVendorAccount
 
 
@@ -25,7 +25,7 @@ class TestVendorAccountService(BaseTestVendorAccount):
         assert vendor_account.name == "Amz-01"
         assert vendor_account.vendor_type == "AMAZON"
 
-    def test_throw_exception_when_vendor_account_with_same_name_and_account_exist(self) -> None:
+    def test_throw_exception_when_vendor_account_with_same_name_account_and_vendor_type_exist(self) -> None:
         # Pre test setup
         params = CreateVendorAccountParams(account_id=self.account_id, name="Amz-01", vendor_type="AMAZON")
 
@@ -36,3 +36,31 @@ class TestVendorAccountService(BaseTestVendorAccount):
             VendorAccountService.create_vendor_account(params)
         except VendorAccountWithSameNameAndAccountExistsError as exc:
             assert exc.code == VendorAccountErrorCode.NAME_ALREADY_EXISTS
+
+    def test_update_vendor_account(self) -> None:
+        # Pre test setup
+        params = CreateVendorAccountParams(account_id=self.account_id, name="Amz-01", vendor_type="AMAZON")
+
+        vendor_account = VendorAccountService.create_vendor_account(params)
+        # Pre test setup end
+
+        update_vendor_account = VendorAccountService.update_vendor_account(
+            params=UpdateVendorAccountParams(
+                account_id=self.account_id, vendor_account_id=vendor_account.id, name="Amz-02"
+            )
+        )
+
+        assert update_vendor_account.account_id == self.account_id
+        assert update_vendor_account.id == vendor_account.id
+        assert update_vendor_account.name == "Amz-02"
+        assert update_vendor_account.vendor_type == "AMAZON"
+
+    def test_throw_exception_when_vendor_account_does_not_exist(self) -> None:
+        try:
+            VendorAccountService.update_vendor_account(
+                params=UpdateVendorAccountParams(
+                    account_id=self.account_id, vendor_account_id="66b2400af6d99e62d6e7992c", name="Amz-02"
+                )
+            )
+        except VendorAccountNotFoundError as exc:
+            assert exc.code == VendorAccountErrorCode.VENDOR_ACCOUNT_NOT_FOUND


### PR DESCRIPTION
## Description
```
URI: PUT /accounts/<account_id>/vendor-accounts/<vendor_account_id>
Body: name
Response status: 200
Response Body: {
    "account": "66b0e501a9667827835aba40",
    "id": "66b1bf6dbe77e7d1618c7ce0",
    "name": "Amz-03",
    "vendor_type": "AMAZON"
}
```

## Database schema changes
- NA
## Tests
### Automated test cases added
- TestVendorAccountService
  - test_update_vendor_account
  - test_throw_exception_when_vendor_account_does_not_exist
- TestVendorAccountApi
  - test_update_vendor_account
  - test_update_vendor_account_with_an_invalid_vendor_account_id
  - test_update_vendor_account_with_duplicate_name

### Manual test cases run


https://github.com/user-attachments/assets/3803662a-1f0a-4b67-9883-4533ade759bf


