### PR TITLE
Feat: API to delete the vendor account

### DIFF
--- a/src/apps/backend/modules/vendor_account/internal/vendor_account_writer.py
+++ b/src/apps/backend/modules/vendor_account/internal/vendor_account_writer.py
@@ -57,7 +57,7 @@ class VendorAccountWriter:
         return VendorAccountUtil.convert_vendor_account_db_to_vendor_account(vendor_account_db=updated_vendor_account)
 
     @staticmethod
-    def delete_vendor_account(params: DeleteVendorAccountParams) -> VendorAccount:
+    def delete_vendor_account(params: DeleteVendorAccountParams) -> None:
         VendorAccountReader.get_vendor_account_by_id(
             account_id=params.account_id, vendor_account_id=params.vendor_account_id
         )

--- a/src/apps/backend/modules/vendor_account/internal/vendor_account_writer.py
+++ b/src/apps/backend/modules/vendor_account/internal/vendor_account_writer.py
@@ -5,7 +5,7 @@ from pymongo import ReturnDocument
 from modules.vendor_account.internal.store.vendor_account_repository import VendorAccountRepository
 from modules.vendor_account.internal.vendor_account_reader import VendorAccountReader
 from modules.vendor_account.internal.vendor_account_util import VendorAccountUtil
-from modules.vendor_account.types import CreateVendorAccountParams, UpdateVendorAccountParams
+from modules.vendor_account.types import CreateVendorAccountParams, DeleteVendorAccountParams, UpdateVendorAccountParams
 from modules.vendor_account.types import VendorAccount
 from modules.vendor_account.errors import VendorAccountWithSameNameAndAccountExistsError
 
@@ -35,7 +35,9 @@ class VendorAccountWriter:
 
     @staticmethod
     def update_vendor_account(params: UpdateVendorAccountParams) -> VendorAccount:
-        vendor_account = VendorAccountReader.get_vendor_account_by_id(account_id=params.account_id, vendor_account_id=params.vendor_account_id)
+        vendor_account = VendorAccountReader.get_vendor_account_by_id(
+            account_id=params.account_id, vendor_account_id=params.vendor_account_id
+        )
 
         duplicate_vendor_account = VendorAccountReader.get_vendor_account_optional(
             account_id=vendor_account.account_id,
@@ -53,3 +55,13 @@ class VendorAccountWriter:
         )
 
         return VendorAccountUtil.convert_vendor_account_db_to_vendor_account(vendor_account_db=updated_vendor_account)
+
+    @staticmethod
+    def delete_vendor_account(params: DeleteVendorAccountParams) -> VendorAccount:
+        VendorAccountReader.get_vendor_account_by_id(
+            account_id=params.account_id, vendor_account_id=params.vendor_account_id
+        )
+
+        VendorAccountRepository.collection().find_one_and_update(
+            {"_id": ObjectId(params.vendor_account_id)}, {"$set": {"active": False}}
+        )

--- a/src/apps/backend/modules/vendor_account/rest_api/vendor_account_router.py
+++ b/src/apps/backend/modules/vendor_account/rest_api/vendor_account_router.py
@@ -15,4 +15,10 @@ class VendorAccountRouter:
             view_func=VendorAccountView.as_view("vendor_account_update"),
             methods=["PUT"],
         )
+
+        blueprint.add_url_rule(
+            "/accounts/<account_id>/vendor-accounts/<vendor_account_id>",
+            view_func=VendorAccountView.as_view("vendor_account_delete"),
+            methods=["DELETE"],
+        )
         return blueprint

--- a/src/apps/backend/modules/vendor_account/rest_api/vendor_account_view.py
+++ b/src/apps/backend/modules/vendor_account/rest_api/vendor_account_view.py
@@ -5,7 +5,7 @@ from flask.typing import ResponseReturnValue
 from flask.views import MethodView
 
 from modules.vendor_account.vendor_account_service import VendorAccountService
-from modules.vendor_account.types import CreateVendorAccountParams, UpdateVendorAccountParams
+from modules.vendor_account.types import CreateVendorAccountParams, DeleteVendorAccountParams, UpdateVendorAccountParams
 from modules.access_token.rest_api.access_auth_middleware import access_auth_middleware
 
 
@@ -27,3 +27,10 @@ class VendorAccountView(MethodView):
         vendor_account = VendorAccountService.update_vendor_account(params=UpdateVendorAccountParams(**request_data))
         vendor_account_dict = asdict(vendor_account)
         return jsonify(vendor_account_dict), 200
+
+    @access_auth_middleware
+    def delete(self, account_id: str, vendor_account_id: str) -> ResponseReturnValue:
+        VendorAccountService.delete_vendor_account(
+            params=DeleteVendorAccountParams(account_id=account_id, vendor_account_id=vendor_account_id)
+        )
+        return jsonify(), 204

--- a/src/apps/backend/modules/vendor_account/types.py
+++ b/src/apps/backend/modules/vendor_account/types.py
@@ -5,6 +5,7 @@ from enum import Enum
 class VendorType(Enum):
     AMAZON = "AMAZON"
 
+
 @dataclass(frozen=True)
 class VendorAccount:
     account_id: str
@@ -12,17 +13,26 @@ class VendorAccount:
     name: str
     vendor_type: VendorType
 
+
 @dataclass(frozen=True)
 class CreateVendorAccountParams:
     account_id: str
     name: str
     vendor_type: VendorType
 
+
 @dataclass(frozen=True)
 class UpdateVendorAccountParams:
     account_id: str
     name: str
     vendor_account_id: str
+
+
+@dataclass(frozen=True)
+class DeleteVendorAccountParams:
+    account_id: str
+    vendor_account_id: str
+
 
 @dataclass(frozen=True)
 class VendorAccountErrorCode:

--- a/src/apps/backend/modules/vendor_account/vendor_account_service.py
+++ b/src/apps/backend/modules/vendor_account/vendor_account_service.py
@@ -1,4 +1,9 @@
-from modules.vendor_account.types import CreateVendorAccountParams, DeleteVendorAccountParams, UpdateVendorAccountParams, VendorAccount
+from modules.vendor_account.types import (
+    CreateVendorAccountParams,
+    DeleteVendorAccountParams,
+    UpdateVendorAccountParams,
+    VendorAccount,
+)
 from modules.vendor_account.internal.vendor_account_writer import VendorAccountWriter
 
 

--- a/src/apps/backend/modules/vendor_account/vendor_account_service.py
+++ b/src/apps/backend/modules/vendor_account/vendor_account_service.py
@@ -1,4 +1,4 @@
-from modules.vendor_account.types import CreateVendorAccountParams, UpdateVendorAccountParams, VendorAccount
+from modules.vendor_account.types import CreateVendorAccountParams, DeleteVendorAccountParams, UpdateVendorAccountParams, VendorAccount
 from modules.vendor_account.internal.vendor_account_writer import VendorAccountWriter
 
 
@@ -10,3 +10,7 @@ class VendorAccountService:
     @staticmethod
     def update_vendor_account(params: UpdateVendorAccountParams) -> VendorAccount:
         return VendorAccountWriter.update_vendor_account(params=params)
+
+    @staticmethod
+    def delete_vendor_account(params: DeleteVendorAccountParams) -> None:
+        return VendorAccountWriter.delete_vendor_account(params=params)

--- a/src/apps/backend/tests/modules/vendor_account/test_vendor_account_api.py
+++ b/src/apps/backend/tests/modules/vendor_account/test_vendor_account_api.py
@@ -150,7 +150,7 @@ class TestVendorAccountApi(BaseTestVendorAccount):
         # Pre test setup end
 
         vendor_account_before = VendorAccountRepository.collection().find_one({"_id": ObjectId(vendor_account.id)})
-        assert vendor_account_before['active'] == True
+        assert vendor_account_before["active"] == True
 
         with app.test_client() as client:
             response = client.delete(
@@ -160,7 +160,7 @@ class TestVendorAccountApi(BaseTestVendorAccount):
             assert response.status_code == 204
 
         vendor_account_after = VendorAccountRepository.collection().find_one({"_id": ObjectId(vendor_account.id)})
-        assert vendor_account_after['active'] == False
+        assert vendor_account_after["active"] == False
 
     def test_delete_vendor_account_with_an_invalid_vendor_account_id(self) -> None:
         with app.test_client() as client:

--- a/src/apps/backend/tests/modules/vendor_account/test_vendor_account_service.py
+++ b/src/apps/backend/tests/modules/vendor_account/test_vendor_account_service.py
@@ -1,8 +1,16 @@
+from bson import ObjectId
+
+from modules.vendor_account.internal.store.vendor_account_repository import VendorAccountRepository
 from modules.account.account_service import AccountService
 from modules.account.types import CreateAccountParams
 from modules.vendor_account.vendor_account_service import VendorAccountService
 from modules.vendor_account.errors import VendorAccountNotFoundError, VendorAccountWithSameNameAndAccountExistsError
-from modules.vendor_account.types import UpdateVendorAccountParams, VendorAccountErrorCode, CreateVendorAccountParams
+from modules.vendor_account.types import (
+    DeleteVendorAccountParams,
+    UpdateVendorAccountParams,
+    VendorAccountErrorCode,
+    CreateVendorAccountParams,
+)
 from tests.modules.vendor_account.base_test_vendor_account import BaseTestVendorAccount
 
 
@@ -55,11 +63,38 @@ class TestVendorAccountService(BaseTestVendorAccount):
         assert update_vendor_account.name == "Amz-02"
         assert update_vendor_account.vendor_type == "AMAZON"
 
-    def test_throw_exception_when_vendor_account_does_not_exist(self) -> None:
+    def test_throw_exception_when_vendor_account_does_not_exist_while_updating_vendor_account(self) -> None:
         try:
             VendorAccountService.update_vendor_account(
                 params=UpdateVendorAccountParams(
                     account_id=self.account_id, vendor_account_id="66b2400af6d99e62d6e7992c", name="Amz-02"
+                )
+            )
+        except VendorAccountNotFoundError as exc:
+            assert exc.code == VendorAccountErrorCode.VENDOR_ACCOUNT_NOT_FOUND
+
+    def test_delete_vendor_account(self) -> None:
+        # Pre test setup
+        params = CreateVendorAccountParams(account_id=self.account_id, name="Amz-01", vendor_type="AMAZON")
+
+        vendor_account = VendorAccountService.create_vendor_account(params)
+        # Pre test setup end
+
+        vendor_account_before = VendorAccountRepository.collection().find_one({"_id": ObjectId(vendor_account.id)})
+        assert vendor_account_before['active'] == True
+
+        VendorAccountService.delete_vendor_account(
+            params=DeleteVendorAccountParams(account_id=self.account_id, vendor_account_id=vendor_account.id)
+        )
+
+        vendor_account_after = VendorAccountRepository.collection().find_one({"_id": ObjectId(vendor_account.id)})
+        assert vendor_account_after['active'] == False
+
+    def test_throw_exception_when_vendor_account_does_not_exist_while_deleting_vendor_account(self) -> None:
+        try:
+            VendorAccountService.delete_vendor_account(
+                params=DeleteVendorAccountParams(
+                    account_id=self.account_id, vendor_account_id="66b2400af6d99e62d6e7992c"
                 )
             )
         except VendorAccountNotFoundError as exc:

--- a/src/apps/backend/tests/modules/vendor_account/test_vendor_account_service.py
+++ b/src/apps/backend/tests/modules/vendor_account/test_vendor_account_service.py
@@ -81,14 +81,14 @@ class TestVendorAccountService(BaseTestVendorAccount):
         # Pre test setup end
 
         vendor_account_before = VendorAccountRepository.collection().find_one({"_id": ObjectId(vendor_account.id)})
-        assert vendor_account_before['active'] == True
+        assert vendor_account_before["active"] == True
 
         VendorAccountService.delete_vendor_account(
             params=DeleteVendorAccountParams(account_id=self.account_id, vendor_account_id=vendor_account.id)
         )
 
         vendor_account_after = VendorAccountRepository.collection().find_one({"_id": ObjectId(vendor_account.id)})
-        assert vendor_account_after['active'] == False
+        assert vendor_account_after["active"] == False
 
     def test_throw_exception_when_vendor_account_does_not_exist_while_deleting_vendor_account(self) -> None:
         try:


### PR DESCRIPTION
## Description
```
URI: DELETE /accounts/<account_id>/vendor-accounts/<vendor_account_id>
Response status: 204
```

## Database schema changes
- NA
## Tests
### Automated test cases added
- TestVendorAccountService
  - test_delete_vendor_account
  - test_throw_exception_when_vendor_account_does_not_exist_while_deleting
- TestVendorAccountApi
  - test_delete_vendor_account
  - test_delete_vendor_account_with_an_invalid_vendor_account_id

### Manual test cases run


https://github.com/user-attachments/assets/243cc8d9-d953-404d-886a-a0ebf31869e2

